### PR TITLE
Rebranded installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Features the following:
 
 # :blue_book: Documentation
 
-Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please [raise an issue](https://github.com/rubrikinc/rdio-ansible-installer/issues/new/choose) and let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie! :heart:
+Here are some resources to get you started! If you find any challenges from this project are not properly documented or are unclear, please [raise an issue](https://github.com/rubrikinc/mosaic-ansible-installer/issues/new/choose) and let us know! This is a fun, safe environment - don't worry if you're a GitHub newbie! :heart:
 
 * [Quick Start Guide](docs/quick-start.md)
 
@@ -24,27 +24,27 @@ Here are some resources to get you started! If you find any challenges from this
 * Requires the following variables data to be defined for any nodes using the this module:
 
 ```text
-   # RDIO Node settings
+   # Mosaic Node settings
 
-    rdio_user: rdio_user
-    rdio_user_pass: Rubrik123!
-    rdio_user_uid: "2018"
-    rdio_user_home: "/home/{{ rdio_user }}"      # must be on a non-root volume
-    rdio_installer_directory: "{{ rdio_user_home }}"
-    rdio_install_file: datos-3.0.1-p3-190329.tar.gz
-    rdio_nfs: False
-    rdio_nfs_mount: /mnt/datos_target
-    rdio_nfs_export: /exports/datos_data
-    rdio_nfs_target: fs1.dom.local
+    mosaic_user: mosaic_user
+    mosaic_user_pass: Rubrik123!
+    mosaic_user_uid: "2018"
+    mosaic_user_home: "/home/{{ mosaic_user }}"      # must be on a non-root volume
+    mosaic_installer_directory: "{{ mosaic_user_home }}"
+    mosaic_install_file: datos-3.0.1-p3-190329.tar.gz
+    mosaic_nfs: False
+    mosaic_nfs_mount: /mnt/datos_target
+    mosaic_nfs_export: /exports/datos_data
+    mosaic_nfs_target: fs1.dom.local
     mongodb: False
     cassdb_minimum_space: 268435456000          #Value in bytes
     mongodb_minimum_space: 1099511627776        #Value in bytes
 
-    #RDIO Data Source settings
+    #Mosaic Data Source settings
 
-    rdio_app_user: rdio_app_user
-    rdio_app_user_pass: Rubrik123!
-    rdio_app_user_home: /home/{{ rdio_app_user }}
+    mosaic_app_user: mosaic_app_user
+    mosaic_app_user_pass: Rubrik123!
+    mosaic_app_user_home: /home/{{ mosaic_app_user }}
 ```
 
 # :muscle: How You Can Help

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Rubrik Datos IO Ansible Deployment
+# Rubrik Mosaic Ansible Deployment
 
-Rubrik Datos IO Ansible role for deploying RecoverX.
+Rubrik Mosaic Ansible role for deploying Mosaic.
 
 Features the following:
 
-* Configuration of new, customer provided, Datos IO nodes
-* Installation of the Datos IO software.
+* Configuration of new, customer provided, Mosaic nodes
+* Installation of the Mosaic software.
 
 # :blue_book: Documentation
 

--- a/ansible/hosts
+++ b/ansible/hosts
@@ -3,9 +3,9 @@ ansible_connection=ssh
 ansible_user=root
 
 [rx]
-rdio-1 ansible_host=192.168.1.10
-rdio-2 ansible_host=192.168.1.11
-rdio-3 ansible_host=192.168.1.12
+mosaic-1 ansible_host=192.168.1.10
+mosaic-2 ansible_host=192.168.1.11
+mosaic-3 ansible_host=192.168.1.12
 
 [cassdb]
 cassdb-1 ansible_host=192.168.1.20

--- a/defaults/vars.yml
+++ b/defaults/vars.yml
@@ -1,23 +1,23 @@
 ---
 
-# RDIO Node settings
+# Mosaic Node settings
 
-rdio_user: rdio_user
-rdio_user_pass: Rubrik123!
-rdio_user_uid: "2018"
-rdio_user_home: "/home/{{ rdio_user }}"      # must be on a non-root volume
-rdio_installer_directory: "{{ rdio_user_home }}"
-rdio_install_file: datos-3.0.1-p3-190329.tar.gz
-rdio_nfs: False
-rdio_nfs_mount: /mnt/datos_target
-rdio_nfs_export: /exports/datos_data
-rdio_nfs_target: fs1.dom.local
+mosaic_user: mosaic_user
+mosaic_user_pass: Rubrik123!
+mosaic_user_uid: "2018"
+mosaic_user_home: "/home/{{ mosaic_user }}"      # must be on a non-root volume
+mosaic_installer_directory: "{{ mosaic_user_home }}"
+mosaic_install_file: datos-3.0.4-190630.tar.gz
+mosaic_nfs: False
+mosaic_nfs_mount: /mnt/datos_target
+mosaic_nfs_export: /mnt/fs1/datos_store
+mosaic_nfs_target: fs1.dom.local
 mongodb: False
 cassdb_minimum_space: 268435456000          #Value in bytes
 mongodb_minimum_space: 1099511627776        #Value in bytes
 
-# RDIO Data Source settings
+#Mosaic Data Source settings
 
-rdio_app_user: rdio_app_user
-rdio_app_user_pass: Rubrik123!
-rdio_app_user_home: /home/rdio_app_user
+mosaic_app_user: mosaic_app_user
+mosaic_app_user_pass: Rubrik123!
+mosaic_app_user_home: /home/mosaic_app_user

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,13 +1,13 @@
 # mosaic-ansible-installer
 
-Ansible role to deploy Rubrik DatosIO RecoverX 3.0 in a single or multi-node deployment on CentOS 7.x x64 or Ubuntu 14 or 16 x64.
+Ansible role to deploy Rubrik Mosaic in a single or multi-node deployment on CentOS 7.x x64 or Ubuntu 14 or 16 x64.
 This role deploys a standard configuration without any Stores/Sources/Schedules/Policies.
 
 ## Role Requirements
 
-### Datos IO Nodes
+### Mosaic Nodes
 
-* Datos IO Nodes: CentOS 7.x, Ubuntu 14.04 or 16.04
+* Mosaic Nodes: CentOS 7.x, Ubuntu 14.04 or 16.04
 * Python 2.7+ or 3.6+
 * Access to the OS package repository to install required packages.
 * Root user password or ssh keys.
@@ -22,13 +22,13 @@ This role deploys a standard configuration without any Stores/Sources/Schedules/
 
 ## Configuration
 
-1. Deploy 1, 3 or 5 CentOS, Red Hat Enterprise Linux, Ubuntu, Amazon Linux or Amazon Linux 2 nodes to act as the Datos IO nodes.
-2. Verify that the DataIO nodes have a non-root filesystem mounted with 300+GB of space. This will be used for the Datos IO user home directory and installation files.
+1. Deploy 1, 3 or 5 CentOS, Red Hat Enterprise Linux, Ubuntu, Amazon Linux or Amazon Linux 2 nodes to act as the Mosaic nodes.
+2. Verify that the DataIO nodes have a non-root filesystem mounted with 300+GB of space. This will be used for the Mosaic user home directory and installation files.
 3. Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on the host that will execute the Ansible role.
-    * This should not be the Datos IO nodes.
+    * This should not be the Mosaic nodes.
 4. Download the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) role from the RubrikInc organization on GitHub to the host that will run Ansible.
-5. Download the Rubrik Datos IO tarball from [Rubrik Support](https://support.rubrik.com)
-6. Place desired DatosIO tarball into the `files/` directory of the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) the prior to role execution.
+5. Download the Rubrik Mosaic tarball from [Rubrik Support](https://support.rubrik.com)
+6. Place desired Mosaic tarball into the `files/` directory of the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) the prior to role execution.
 7. Verify that the extract directory for the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) is not world writable.
      * Run `chmod 755 ./mosaic-ansible-installer`
      * If this cannot be avoided run `export ANSIBLE_CONFIG=./ansible/ansible.cfg`
@@ -60,23 +60,23 @@ This role deploys a standard configuration without any Stores/Sources/Schedules/
 
     | Variable | Description |
     | -------- | ----------- |
-    | `mosaic_user` | User to create that will run Datos IO on the Datos IO nodes |
-    | `mosaic_user_pass` | Password of the Datos IO user |
-    | `mosaic_user_uid` | The UUID of the Datos IO user on the Datos IO nodes. |
-    | `mosaic_user_home` | Home directory of the Datos IO user. This must be on a non-root volume. |
-    | `mosaic_installer_directory` | Directory where the Datos IO software should be installed on the Datos IO nodes. Default is the Datos IO user's home directory. |
-    | `mosaic_install_file` | Name of the Datos IO tarball to deploy. Should be placed in `files/` |
+    | `mosaic_user` | User to create that will run Mosaic on the Mosaic nodes |
+    | `mosaic_user_pass` | Password of the Mosaic user |
+    | `mosaic_user_uid` | The UUID of the Mosaic user on the Mosaic nodes. |
+    | `mosaic_user_home` | Home directory of the Mosaic user. This must be on a non-root volume. |
+    | `mosaic_installer_directory` | Directory where the Mosaic software should be installed on the Mosaic nodes. Default is the Mosaic user's home directory. |
+    | `mosaic_install_file` | Name of the Mosaic tarball to deploy. Should be placed in `files/` |
     | `mosaic_nfs` | Set to 'True' if NFS storage will be used as the data store. |
-    | `mosaic_nfs_mount` | Mount point for the NFS data store on the Datos IO servers (if NFS will be used). |
+    | `mosaic_nfs_mount` | Mount point for the NFS data store on the Mosaic servers (if NFS will be used). |
     | `mosaic_nfs_export` | Export on the NFS server (if NFS will be used). |
     | `mosaic_nfs_target` | Hostname or IP address of the NFS server (if NFS will be used). |
     | `mongodb` | Set to 'True' if using MongoDB as a data source, as this will enable the required fuse configuration changes. |
-    | `cassdb_minimum_space` | The minimum space in bytes required on the Datos IO nodes in the `mosaic_user_home` directory for Cassandra protection. |
-    | `mongodb_minimum_space` | The minimum space in bytes required on the Datos IO nodes in the `mosaic_user_home` directory for MongoDB protection. |
+    | `cassdb_minimum_space` | The minimum space in bytes required on the Mosaic nodes in the `mosaic_user_home` directory for Cassandra protection. |
+    | `mongodb_minimum_space` | The minimum space in bytes required on the Mosaic nodes in the `mosaic_user_home` directory for MongoDB protection. |
 
-    | `mosaic_app_user` | User to create on the data source that will run the Datos IO agent. |
-    | `mosaic_app_user_pass` | Password of the Datos IO Application User. |
-    | `mosaic_app_user_home` | Home directory of the Datos IO Application User. |
+    | `mosaic_app_user` | User to create on the data source that will run the Mosaic agent. |
+    | `mosaic_app_user_pass` | Password of the Mosaic Application User. |
+    | `mosaic_app_user_home` | Home directory of the Mosaic Application User. |
   
 9. Edit the `ansible/hosts` inventory file:
 
@@ -101,12 +101,12 @@ This role deploys a standard configuration without any Stores/Sources/Schedules/
     mongodb-3 ansible_host=192.168.1.32
     ```
 
-   * All Datos IO nodes should be part of the `rx` group
+   * All Mosaic nodes should be part of the `rx` group
    * All Cassandra database nodes should be part of the `cassdb` group
    * All MongoDB nodes should be part of the `mongodb` group
    * List each host with the format `<hostname> ansible_host=<ip_address>`
 
-10. Run the ansible-playbook command to install Datos IO based on your configuration:
+10. Run the ansible-playbook command to install Mosaic based on your configuration:
     * With out ssh keys installed for root on each node:
 
     ```bash
@@ -123,7 +123,7 @@ This role deploys a standard configuration without any Stores/Sources/Schedules/
     ansible-playbook -l rx -i ansible/hosts install-rx.yml
     ```
 
-    * The -l option on `ansible-playbook` limits the instal to just the Datos IO nodes. Database Sources are still being tested.
+    * The -l option on `ansible-playbook` limits the instal to just the Mosaic nodes. Database Sources are still being tested.
 
 ## License
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -1,4 +1,4 @@
-# rdio-ansible-installer
+# mosaic-ansible-installer
 
 Ansible role to deploy Rubrik DatosIO RecoverX 3.0 in a single or multi-node deployment on CentOS 7.x x64 or Ubuntu 14 or 16 x64.
 This role deploys a standard configuration without any Stores/Sources/Schedules/Policies.
@@ -26,57 +26,57 @@ This role deploys a standard configuration without any Stores/Sources/Schedules/
 2. Verify that the DataIO nodes have a non-root filesystem mounted with 300+GB of space. This will be used for the Datos IO user home directory and installation files.
 3. Install [Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on the host that will execute the Ansible role.
     * This should not be the Datos IO nodes.
-4. Download the [Ansible RDIO Deployment Role](https://github.com/rubrikinc/rdio-ansible-installer) role from the RubrikInc organization on GitHub to the host that will run Ansible.
+4. Download the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) role from the RubrikInc organization on GitHub to the host that will run Ansible.
 5. Download the Rubrik Datos IO tarball from [Rubrik Support](https://support.rubrik.com)
-6. Place desired DatosIO tarball into the `files/` directory of the [Ansible RDIO Deployment Role](https://github.com/rubrikinc/rdio-ansible-installer) the prior to role execution.
-7. Verify that the extract directory for the [Ansible RDIO Deployment Role](https://github.com/rubrikinc/rdio-ansible-installer) is not world writable.
-     * Run `chmod 755 ./rdio-ansible-installer`
+6. Place desired DatosIO tarball into the `files/` directory of the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) the prior to role execution.
+7. Verify that the extract directory for the [Ansible Mosaic Deployment Role](https://github.com/rubrikinc/mosaic-ansible-installer) is not world writable.
+     * Run `chmod 755 ./mosaic-ansible-installer`
      * If this cannot be avoided run `export ANSIBLE_CONFIG=./ansible/ansible.cfg`
 8. Edit the role variables in the `defaults/vars.yml` file.
 
     ```text
-    # RDIO Node settings
+    # Mosaic Node settings
 
-    rdio_user: rdio_user
-    rdio_user_pass: Rubrik123!
-    rdio_user_uid: "2018"
-    rdio_user_home: "/home/{{ rdio_user }}"      # must be on a non-root volume
-    rdio_installer_directory: "{{ rdio_user_home }}"
-    rdio_install_file: datos-3.0.1-p3-190329.tar.gz
-    rdio_nfs: False
-    rdio_nfs_mount: /mnt/datos_target
-    rdio_nfs_export: /exports/datos_data
-    rdio_nfs_target: fs1.dom.local
+    mosaic_user: mosaic_user
+    mosaic_user_pass: Rubrik123!
+    mosaic_user_uid: "2018"
+    mosaic_user_home: "/home/{{ mosaic_user }}"      # must be on a non-root volume
+    mosaic_installer_directory: "{{ mosaic_user_home }}"
+    mosaic_install_file: datos-3.0.1-p3-190329.tar.gz
+    mosaic_nfs: False
+    mosaic_nfs_mount: /mnt/datos_target
+    mosaic_nfs_export: /exports/datos_data
+    mosaic_nfs_target: fs1.dom.local
     mongodb: False
     cassdb_minimum_space: 268435456000          #Value in bytes
     mongodb_minimum_space: 1099511627776        #Value in bytes
 
-    # RDIO Data Source settings
+    # Mosaic Data Source settings
 
-    rdio_app_user: rdio_app_user
-    rdio_app_user_pass: Rubrik123!
-    rdio_app_user_home: /home/{{ rdio_app_user }}
+    mosaic_app_user: mosaic_app_user
+    mosaic_app_user_pass: Rubrik123!
+    mosaic_app_user_home: /home/{{ mosaic_app_user }}
     ```
 
     | Variable | Description |
     | -------- | ----------- |
-    | `rdio_user` | User to create that will run Datos IO on the Datos IO nodes |
-    | `rdio_user_pass` | Password of the Datos IO user |
-    | `rdio_user_uid` | The UUID of the Datos IO user on the Datos IO nodes. |
-    | `rdio_user_home` | Home directory of the Datos IO user. This must be on a non-root volume. |
-    | `rdio_installer_directory` | Directory where the Datos IO software should be installed on the Datos IO nodes. Default is the Datos IO user's home directory. |
-    | `rdio_install_file` | Name of the Datos IO tarball to deploy. Should be placed in `files/` |
-    | `rdio_nfs` | Set to 'True' if NFS storage will be used as the data store. |
-    | `rdio_nfs_mount` | Mount point for the NFS data store on the Datos IO servers (if NFS will be used). |
-    | `rdio_nfs_export` | Export on the NFS server (if NFS will be used). |
-    | `rdio_nfs_target` | Hostname or IP address of the NFS server (if NFS will be used). |
+    | `mosaic_user` | User to create that will run Datos IO on the Datos IO nodes |
+    | `mosaic_user_pass` | Password of the Datos IO user |
+    | `mosaic_user_uid` | The UUID of the Datos IO user on the Datos IO nodes. |
+    | `mosaic_user_home` | Home directory of the Datos IO user. This must be on a non-root volume. |
+    | `mosaic_installer_directory` | Directory where the Datos IO software should be installed on the Datos IO nodes. Default is the Datos IO user's home directory. |
+    | `mosaic_install_file` | Name of the Datos IO tarball to deploy. Should be placed in `files/` |
+    | `mosaic_nfs` | Set to 'True' if NFS storage will be used as the data store. |
+    | `mosaic_nfs_mount` | Mount point for the NFS data store on the Datos IO servers (if NFS will be used). |
+    | `mosaic_nfs_export` | Export on the NFS server (if NFS will be used). |
+    | `mosaic_nfs_target` | Hostname or IP address of the NFS server (if NFS will be used). |
     | `mongodb` | Set to 'True' if using MongoDB as a data source, as this will enable the required fuse configuration changes. |
-    | `cassdb_minimum_space` | The minimum space in bytes required on the Datos IO nodes in the `rdio_user_home` directory for Cassandra protection. |
-    | `mongodb_minimum_space` | The minimum space in bytes required on the Datos IO nodes in the `rdio_user_home` directory for MongoDB protection. |
+    | `cassdb_minimum_space` | The minimum space in bytes required on the Datos IO nodes in the `mosaic_user_home` directory for Cassandra protection. |
+    | `mongodb_minimum_space` | The minimum space in bytes required on the Datos IO nodes in the `mosaic_user_home` directory for MongoDB protection. |
 
-    | `rdio_app_user` | User to create on the data source that will run the Datos IO agent. |
-    | `rdio_app_user_pass` | Password of the Datos IO Application User. |
-    | `rdio_app_user_home` | Home directory of the Datos IO Application User. |
+    | `mosaic_app_user` | User to create on the data source that will run the Datos IO agent. |
+    | `mosaic_app_user_pass` | Password of the Datos IO Application User. |
+    | `mosaic_app_user_home` | Home directory of the Datos IO Application User. |
   
 9. Edit the `ansible/hosts` inventory file:
 
@@ -86,9 +86,9 @@ This role deploys a standard configuration without any Stores/Sources/Schedules/
     ansible_user=root
 
     [rx]
-    rdio-1 ansible_host=192.168.1.10
-    rdio-2 ansible_host=192.168.1.11
-    rdio-3 ansible_host=192.168.1.12
+    mosaic-1 ansible_host=192.168.1.10
+    mosaic-2 ansible_host=192.168.1.11
+    mosaic-3 ansible_host=192.168.1.12
 
     [cassdb]
     cassdb-1 ansible_host=192.168.1.20

--- a/tasks/db-os-prep.yml
+++ b/tasks/db-os-prep.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Add Rubrik DatosIO App User for Cassandra
+- name: Add Rubrik Mosaic App User for Cassandra
   user:
     name: "{{ mosaic_app_user }}"
     shell: /bin/bash
@@ -12,7 +12,7 @@
   register: new_app_user
   when: "'cassdb' in group_names"
 
-- name: Add Rubrik DatosIO App User for MongoDB
+- name: Add Rubrik Mosaic App User for MongoDB
   user:
     name: "{{ mosaic_app_user }}"
     shell: /bin/bash
@@ -64,7 +64,7 @@
     group: "{{ mosaic_app_user }}"
     mode: 0644
 
-- name: Allow Datos IO user to have passwordless sudo
+- name: Allow Mosaic user to have passwordless sudo
   lineinfile:
     dest: /etc/sudoers
     state: present

--- a/tasks/db-os-prep.yml
+++ b/tasks/db-os-prep.yml
@@ -2,44 +2,44 @@
 
 - name: Add Rubrik DatosIO App User for Cassandra
   user:
-    name: "{{ rdio_app_user }}"
+    name: "{{ mosaic_app_user }}"
     shell: /bin/bash
     groups: cassandra
     append: yes
     state: present
     createhome: yes
-    home: "{{ rdio_app_user_home }}"
+    home: "{{ mosaic_app_user_home }}"
   register: new_app_user
   when: "'cassdb' in group_names"
 
 - name: Add Rubrik DatosIO App User for MongoDB
   user:
-    name: "{{ rdio_app_user }}"
+    name: "{{ mosaic_app_user }}"
     shell: /bin/bash
     groups: mongodb
     append: yes
     state: present
     createhome: yes
-    home: "{{ rdio_app_user_home }}"
+    home: "{{ mosaic_app_user_home }}"
   register: new_app_user
   when: "'mongodb' in group_names"
 
-- name: Ensure that free space on "{{ rdio_app_user_home }}" is grater than 10MB
+- name: Ensure that free space on "{{ mosaic_app_user_home }}" is grater than 10MB
   assert:
     that: mount.size_available < float 10485760
-    msg: Disk space on "{{ rdio_app_user_home }}" is less than 10MB. Increase before performing backups
+    msg: Disk space on "{{ mosaic_app_user_home }}" is less than 10MB. Increase before performing backups
   vars:
-    mount: "{{ ansible_mounts | selectattr('mount','equalto',rdio_app_user_home) | list | first }}"
+    mount: "{{ ansible_mounts | selectattr('mount','equalto',mosaic_app_user_home) | list | first }}"
 
-- name: Set RDIO user password
+- name: Set Mosaic user password
   user:
-    name: "{{ rdio_app_user }}"
-    password: "{{ rdio_app_user_pass | password_hash('sha512') }}"
+    name: "{{ mosaic_app_user }}"
+    password: "{{ mosaic_app_user_pass | password_hash('sha512') }}"
   when: new_app_user is changed
 
 - name: Add SSH authorized key
   authorized_key:
-    user: "{{ rdio_app_user }}"
+    user: "{{ mosaic_app_user }}"
     state: present
     key: "{{ item }}"
   with_file:
@@ -48,9 +48,9 @@
 - name: Copy SSH keys
   copy:
     src: "{{ item.file }}"
-    dest: "{{ rdio_app_user_home }}/.ssh/{{ item.file }}"
-    owner: "{{ rdio_app_user }}"
-    group: "{{ rdio_app_user }}"
+    dest: "{{ mosaic_app_user_home }}/.ssh/{{ item.file }}"
+    owner: "{{ mosaic_app_user }}"
+    group: "{{ mosaic_app_user }}"
     mode: "{{ item.mode }}"
   with_items:
     - { file: 'app_id_rsa', mode: '0400' }
@@ -59,22 +59,22 @@
 - name: Deploy SSH Pubkey Template
   template:
     src: known_hosts.j2
-    dest: "{{ rdio_app_user_home }}/.ssh/known_hosts"
-    owner: "{{ rdio_app_user }}"
-    group: "{{ rdio_app_user }}"
+    dest: "{{ mosaic_app_user_home }}/.ssh/known_hosts"
+    owner: "{{ mosaic_app_user }}"
+    group: "{{ mosaic_app_user }}"
     mode: 0644
 
 - name: Allow Datos IO user to have passwordless sudo
   lineinfile:
     dest: /etc/sudoers
     state: present
-    regexp: '{{ rdio_app_user }}'
-    line: '^{{ rdio_app_user }} ALL=NOPASSWD: ALL'
+    regexp: '{{ mosaic_app_user }}'
+    line: '^{{ mosaic_app_user }} ALL=NOPASSWD: ALL'
     validate: 'visudo -cf %s'
 
-- name: Set permissions on "{{ rdio_app_user_home }}"
+- name: Set permissions on "{{ mosaic_app_user_home }}"
   file:
-    dest: "{{ rdio_app_user_home }}"
+    dest: "{{ mosaic_app_user_home }}"
     mode: 0755
     recurse: yes
   become: yes

--- a/tasks/main-rx.yml
+++ b/tasks/main-rx.yml
@@ -1,10 +1,10 @@
 ---
 
-- name: Include RecoverX OS specific tasks
+- name: Include Mosaic OS specific tasks
   include_tasks: "rx-os-prep.yml"
   tags: rxosprep
 
-- name: Include RecoverX specific tasks
+- name: Include Mosaic specific tasks
   include_tasks: "rx-install.yml"
   when: "'rx' in group_names"
   tags: rx

--- a/tasks/rx-install.yml
+++ b/tasks/rx-install.yml
@@ -2,74 +2,74 @@
  
 - name: Add Rubrik Datos IO group
   group:
-    name: "rdio"
+    name: "mosaic"
     state: present
   register: new_group
 
 - name: Add Rubrik DatosIO User
   user:
-    name: "{{ rdio_user }}"
+    name: "{{ mosaic_user }}"
     shell: /bin/bash
-    groups: rdio
+    groups: mosaic
     append: yes
     state: present
     createhome: yes
-    home: "{{ rdio_user_home }}"
-    uid: "{{ rdio_user_uid }}"
+    home: "{{ mosaic_user_home }}"
+    uid: "{{ mosaic_user_uid }}"
   register: new_user
 
-- name: Set RDIO user password
+- name: Set Mosaic user password
   user:
-    name: "{{ rdio_user }}"
-    password: "{{ rdio_user_pass | password_hash('sha512') }}"
+    name: "{{ mosaic_user }}"
+    password: "{{ mosaic_user_pass | password_hash('sha512') }}"
   when: new_user is changed
 
-- name: Determine mount point of "{{ rdio_user_home }}"
-  command: "/usr/bin/env stat -c '%m' {{ rdio_user_home }}"
-  register: rdio_user_home_mount_point
+- name: Determine mount point of "{{ mosaic_user_home }}"
+  command: "/usr/bin/env stat -c '%m' {{ mosaic_user_home }}"
+  register: mosaic_user_home_mount_point
   changed_when: False
 
-- name: "(Cassandra) Verifying that free space on {{ rdio_user_home_mount_point.stdout }} is greater than {{ cassdb_minimum_space }} bytes."
+- name: "(Cassandra) Verifying that free space on {{ mosaic_user_home_mount_point.stdout }} is greater than {{ cassdb_minimum_space }} bytes."
   assert:
     that: "{{ item.size_available > cassdb_minimum_space }}"
     fail_msg: |
-      "Disk space on {{ rdio_user_home_mount_point.stdout }} is {{ item.size_available }} bytes.
+      "Disk space on {{ mosaic_user_home_mount_point.stdout }} is {{ item.size_available }} bytes.
       This is less than than the minimum of {{ cassdb_minimum_space }} bytes.
-      Increase the capacity of {{ rdio_user_home_mount_point.stdout }} before proceeding."
-    success_msg: Free space on "{{ rdio_user_home_mount_point.stdout }}" is ok. 
+      Increase the capacity of {{ mosaic_user_home_mount_point.stdout }} before proceeding."
+    success_msg: Free space on "{{ mosaic_user_home_mount_point.stdout }}" is ok. 
     quiet: true
   with_items: "{{ ansible_mounts }}"
   when: 
-    - item.mount == rdio_user_home_mount_point.stdout
+    - item.mount == mosaic_user_home_mount_point.stdout
     - not mongodb | bool
 
-- name: "(MongoDB) Verifying that free space on {{ rdio_user_home_mount_point.stdout }} is greater than {{ mongodb_minimum_space }} bytes."
+- name: "(MongoDB) Verifying that free space on {{ mosaic_user_home_mount_point.stdout }} is greater than {{ mongodb_minimum_space }} bytes."
   assert:
     that: "{{ item.size_available > mongodb_minimum_space }}"
     fail_msg: |
-      "Disk space on {{ rdio_user_home_mount_point.stdout }} is {{ item.size_available }} bytes.
+      "Disk space on {{ mosaic_user_home_mount_point.stdout }} is {{ item.size_available }} bytes.
       This is less than than the minimum of {{ mongodb_minimum_space }} bytes.
-      Increase the capacity of {{ rdio_user_home_mount_point.stdout }} before proceeding."
-    success_msg: Free space on "{{ rdio_user_home_mount_point.stdout }}" is ok. 
+      Increase the capacity of {{ mosaic_user_home_mount_point.stdout }} before proceeding."
+    success_msg: Free space on "{{ mosaic_user_home_mount_point.stdout }}" is ok. 
     quiet: true
   with_items: "{{ ansible_mounts }}"
   when: 
-    - item.mount == rdio_user_home_mount_point.stdout
+    - item.mount == mosaic_user_home_mount_point.stdout
     - mongodb | bool
 
 - name: Create ~/.ssh directory 
   file:
-    path: "{{ rdio_user_home }}/.ssh"
+    path: "{{ mosaic_user_home }}/.ssh"
     state: directory
     mode: 0700
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
 
 - name: Create SSH Keys
-  command: ssh-keygen -b 4096 -t rsa -N "" -f "{{ rdio_user_home }}/.ssh/id_rsa"
+  command: ssh-keygen -b 4096 -t rsa -N "" -f "{{ mosaic_user_home }}/.ssh/id_rsa"
   args:
-    creates: "{{ rdio_user_home }}/.ssh/id_rsa"
+    creates: "{{ mosaic_user_home }}/.ssh/id_rsa"
   register: create_keys
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
   when: inventory_hostname == groups['rx'][0]
 
 - name: Grab ssh keys
@@ -78,8 +78,8 @@
     dest: files/
     flat: yes
   with_items:
-    - "{{ rdio_user_home }}/.ssh/id_rsa"
-    - "{{ rdio_user_home }}/.ssh/id_rsa.pub"
+    - "{{ mosaic_user_home }}/.ssh/id_rsa"
+    - "{{ mosaic_user_home }}/.ssh/id_rsa.pub"
   when: 
     - inventory_hostname == groups['rx'][0]
     - create_keys is changed
@@ -87,9 +87,9 @@
 - name: Copy SSH keys
   copy:
     src: "files/{{ item.file }}"
-    dest: "{{ rdio_user_home }}/.ssh/{{ item.file }}"
-    owner: "{{ rdio_user }}"
-    group: "{{ rdio_user }}"
+    dest: "{{ mosaic_user_home }}/.ssh/{{ item.file }}"
+    owner: "{{ mosaic_user }}"
+    group: "{{ mosaic_user }}"
     mode: "{{ item.mode }}"
   with_items:
     - { file: 'id_rsa', mode: '0400' }
@@ -97,12 +97,12 @@
 
 - name: Add SSH authorized key
   authorized_key:
-    user: "{{ rdio_user }}"
+    user: "{{ mosaic_user }}"
     state: present
     key: "{{ item }}"
   with_file:
      - files/id_rsa.pub
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
   loop_control:
     label: "Updated authorized_hosts."
 
@@ -111,14 +111,14 @@
     path: ~/.ssh/known_hosts
     mode: 0644
     state: touch
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
 
 - name: Deploy SSH Public Key Template
   template:
     src: known_hosts.j2
-    dest: "{{ rdio_user_home }}/.ssh/known_hosts"
-    owner: "{{ rdio_user }}"
-    group: "{{ rdio_user }}"
+    dest: "{{ mosaic_user_home }}/.ssh/known_hosts"
+    owner: "{{ mosaic_user }}"
+    group: "{{ mosaic_user }}"
     mode: 0644
 
 - name: CentOS/Red Hat - Modify pam limits
@@ -185,65 +185,65 @@
 - name: Deploy RecoverX Node Template
   template:
     src: nodes.j2
-    dest: "{{ rdio_user_home }}/nodes"
-    owner: "{{ rdio_user }}"
-    group: "{{ rdio_user }}"
+    dest: "{{ mosaic_user_home }}/nodes"
+    owner: "{{ mosaic_user }}"
+    group: "{{ mosaic_user }}"
   become: true
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
   when: inventory_hostname == groups['rx'][0]
 
 - name: Detect and register Nodes
   slurp:
-    src: "{{ rdio_user_home }}/nodes"
+    src: "{{ mosaic_user_home }}/nodes"
   register: nodes
   when: inventory_hostname == groups['rx'][0]
 
 - name: Detect existing RecoverX installation
   stat:
-    path: "{{ rdio_installer_directory }}/datosinstall"
-  register: rdio_dir
+    path: "{{ mosaic_installer_directory }}/datosinstall"
+  register: mosaic_dir
   changed_when: False
   ignore_errors: True
 
-- name: Create/verify Installer directory {{ rdio_installer_directory }}
+- name: Create/verify Installer directory {{ mosaic_installer_directory }}
   file:
-    path: "{{ rdio_installer_directory }}"
+    path: "{{ mosaic_installer_directory }}"
     state: directory
     mode: 0700
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
 
-- name: Copy RDIO release file to {{ groups['rx'][0] }} - {{ rdio_install_file }}
+- name: Copy Mosaic release file to {{ groups['rx'][0] }} - {{ mosaic_install_file }}
   unarchive:
-    src: "{{ rdio_install_file }}"
-    dest: "{{ rdio_installer_directory }}/"
-    owner: "{{ rdio_user }}"
-    group: "{{ rdio_user }}"
+    src: "{{ mosaic_install_file }}"
+    dest: "{{ mosaic_installer_directory }}/"
+    owner: "{{ mosaic_user }}"
+    group: "{{ mosaic_user }}"
     list_files: true
   become: true
-  become_user: "{{ rdio_user }}"
+  become_user: "{{ mosaic_user }}"
   register: deploy_files
   when: 
     - inventory_hostname == groups['rx'][0]
-    - not rdio_dir.stat.exists
+    - not mosaic_dir.stat.exists
 
-- name: Install RecoverX - {{ rdio_install_file }}
+- name: Install RecoverX - {{ mosaic_install_file }}
   shell: >
-    ./install_datos
-    -i {{ nodes['content'] | b64decode }}
-    -t {{ rdio_installer_directory }}/datosinstall
+    ./install_datos 
+    -i {{ nodes['content'] | b64decode }} 
+    -t {{ mosaic_installer_directory }}/datosinstall 
     --skip-eula-check
   args:
-    chdir: "{{ rdio_installer_directory }}/{{ deploy_files.files[0] }}"
+    chdir: "{{ mosaic_installer_directory }}/{{ deploy_files.files[0] }}"
   become: true
-  become_user: "{{ rdio_user }}"
-  register: rdio_install
+  become_user: "{{ mosaic_user }}"
+  register: mosaic_install
   when:
-    - not rdio_dir.stat.exists
+    - not mosaic_dir.stat.exists
     - inventory_hostname == groups['rx'][0]
 
 - name: Deploy RecoverX init script
   copy:
-    src: "{{ rdio_installer_directory }}/datosinstall/datos-server"
+    src: "{{ mosaic_installer_directory }}/datosinstall/datos-server"
     dest: /etc/init.d/datos-server
     remote_src: true
     owner: root
@@ -266,7 +266,7 @@
 
 - name: Change permissions of fusermount
   file:
-    path: "{{ rdio_installer_directory }}/datosinstall/lib/fuse/bin/fusermount"
+    path: "{{ mosaic_installer_directory }}/datosinstall/lib/fuse/bin/fusermount"
     owner: root
     mode: "u+s"
   become: true
@@ -293,24 +293,24 @@
 
 - name: Create NFS Mount point
   file:
-    path: "{{ rdio_nfs_mount }}"
-    owner: "{{ rdio_user }}"
-    group: rdio
+    path: "{{ mosaic_nfs_mount }}"
+    owner: "{{ mosaic_user }}"
+    group: mosaic
     state: directory
     mode: 0755
   when: 
-    - rdio_nfs | bool
+    - mosaic_nfs | bool
   become: true
 
 - name: Mount NFS storage
   mount:
-    path: "{{ rdio_nfs_mount }}"
-    src: "{{ rdio_nfs_target }}:{{ rdio_nfs_export }}"
+    path: "{{ mosaic_nfs_mount }}"
+    src: "{{ mosaic_nfs_target }}:{{ mosaic_nfs_export }}"
     fstype: nfs
     opts: nfsvers=3,auto,hard,actimeo=0,lookupcache=none,noac
     state: mounted
   when: 
-    - rdio_nfs | bool
+    - mosaic_nfs | bool
   become: true
 
 - name: Update hosts tables with MongoDB host names

--- a/tasks/rx-install.yml
+++ b/tasks/rx-install.yml
@@ -229,7 +229,7 @@
 - name: Install RecoverX - {{ mosaic_install_file }}
   shell: >
     ./install_datos 
-    -i {{ nodes['content'] | b64decode }} 
+    -i {{ nodes['content'] | b64decode | trim }} 
     -t {{ mosaic_installer_directory }}/datosinstall 
     --skip-eula-check
   args:

--- a/tasks/rx-install.yml
+++ b/tasks/rx-install.yml
@@ -1,12 +1,12 @@
 ---
  
-- name: Add Rubrik Datos IO group
+- name: Add Rubrik Mosaic group
   group:
     name: "mosaic"
     state: present
   register: new_group
 
-- name: Add Rubrik DatosIO User
+- name: Add Rubrik Mosaic User
   user:
     name: "{{ mosaic_user }}"
     shell: /bin/bash
@@ -182,7 +182,7 @@
     - '* soft nproc 64000'
   when: ansible_os_family == 'RedHat'
 
-- name: Deploy RecoverX Node Template
+- name: Deploy Mosaic Node Template
   template:
     src: nodes.j2
     dest: "{{ mosaic_user_home }}/nodes"
@@ -198,7 +198,7 @@
   register: nodes
   when: inventory_hostname == groups['rx'][0]
 
-- name: Detect existing RecoverX installation
+- name: Detect existing Mosaic installation
   stat:
     path: "{{ mosaic_installer_directory }}/datosinstall"
   register: mosaic_dir
@@ -226,7 +226,7 @@
     - inventory_hostname == groups['rx'][0]
     - not mosaic_dir.stat.exists
 
-- name: Install RecoverX - {{ mosaic_install_file }}
+- name: Install Mosaic - {{ mosaic_install_file }}
   shell: >
     ./install_datos 
     -i {{ nodes['content'] | b64decode | trim }} 
@@ -241,7 +241,7 @@
     - not mosaic_dir.stat.exists
     - inventory_hostname == groups['rx'][0]
 
-- name: Deploy RecoverX init script
+- name: Deploy Mosaic init script
   copy:
     src: "{{ mosaic_installer_directory }}/datosinstall/datos-server"
     dest: /etc/init.d/datos-server
@@ -250,13 +250,13 @@
     group: root
     mode: 0755
 
-- name: Enable RecoverX service
+- name: Enable Mosaic service
   service:
     name: datos-server
     enabled: yes
     state: started
 
-- name: Initialize RecoverX subsystem
+- name: Initialize Mosaic subsystem
   file:
     path: /var/lock/subsys/datos-server
     owner: root
@@ -316,14 +316,14 @@
 - name: Update hosts tables with MongoDB host names
   debug:
     msg: | 
-      -- Manual Step -- [For MongoDB Only] MongoDB node host names need to be resolvable from the Rubrik Datos IO server. 
+      -- Manual Step -- [For MongoDB Only] MongoDB node host names need to be resolvable from the Rubrik Mosaic server. 
       To do so, connect to the config server and get host names of all MongoDB instances in the MongoDB cluster.
 
       $mongo --host <config_ip> --port <config_port>
       config:PRIMARY> use config
       config:PRIMARY> db.mongos.find() //the output of this command will show the mongos hostname and associated IP
       
-      Next, on Rubrik Datos IO server, add a hostname entry for each mongos with its hostname and IP address from above.
+      Next, on Rubrik Mosaic server, add a hostname entry for each mongos with its hostname and IP address from above.
   when: 
     - mongodb | bool
   run_once: true

--- a/tasks/rx-os-prep.yml
+++ b/tasks/rx-os-prep.yml
@@ -79,6 +79,6 @@
   lineinfile:
     dest: /etc/sudoers
     state: present
-    regexp: '^{{ rdio_user }}'
-    line: '{{ rdio_user }} ALL=NOPASSWD: /bin/chmod, /bin/chown, /sbin/modprobe, /bin/mount, /sbin/sysctl'
+    regexp: '^{{ mosaic_user }}'
+    line: '{{ mosaic_user }} ALL=NOPASSWD: /bin/chmod, /bin/chown, /sbin/modprobe, /bin/mount, /sbin/sysctl'
     validate: 'visudo -cf %s'

--- a/tasks/rx-os-prep.yml
+++ b/tasks/rx-os-prep.yml
@@ -75,7 +75,7 @@
     state: enabled
   when: ansible_os_family == 'Debian' and ufw_present.stat.exists
 
-- name: Allow Datos IO user to have passwordless sudo
+- name: Allow Mosaic user to have passwordless sudo
   lineinfile:
     dest: /etc/sudoers
     state: present


### PR DESCRIPTION
# Description

Rebranded the installer and the objects it creates from RDIO to Mosaic

## Related Issue

Fixes #4 

## Motivation and Context

RDIO was rebranded as Mosaic. The installer needed to follow suit.

## How Has This Been Tested?

Deployed Mosaic v3.0.1 on both Unbuntu and CentOS using the rebranded installer.

## Types of changes

What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

Go over all the following points, and put an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help!

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **[CONTRIBUTION](https://github.com/rubrikinc/welcome-to-rubrik-build/blob/master/CONTRIBUTING.md)** document.
- [ ] I have updated the CHANGELOG file accordingly for the version that this merge modifies.